### PR TITLE
Add a README to the android repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# Android
+
+This repository contains code for the native android app that displays the [air partners web application](https://github.com/airpartners/aq-web-client) 
+and includes some Android-specific content for releases. As we update the web app, we'll need to ensure that this app continues
+to display the web app as expected and add android-specific features (like notifications, location services, etc.).
+
+For more information about development and deployment, check out the [Android wiki](https://github.com/airpartners/Android/wiki/).


### PR DESCRIPTION
Copied the style of the IOS README, mainly just points to the web app and to the wiki.